### PR TITLE
Set the correct environment variables in dismod AT and at cascade containers

### DIFF
--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -477,6 +477,10 @@ cd ..
 # Restore run_cmake.sh to its original state
 Run git checkout bin/run_cmake.sh
 
+# Set the correct PATH and PYTHONPATH so dismod_at is findable
+ENV PYTHONPATH=/home/prefix
+ENV PATH="$PATH:/home/prefix/dismod_at/bin"
+
 WORKDIR /home/work
 EOF
 # ----------------------------------------------------------------------------
@@ -504,9 +508,10 @@ ln -s $dir/dismod_at.release $dir/dismod_at
 
 # 2. Test debug
 WORKDIR /home/at_cascade.git
+# ENV PYTHONPATH=$dir:/home/at_cascade.git
+ENV PYTHONPATH=$dir/dismod_at/lib/python3.8/site-packages:/home/at_cascade.git
+ENV PATH="$PATH:$dir/dismod_at/bin"
 RUN \
-export PATH="\$PATH:$dir/dismod_at/bin" && \
-export PYTHONPATH=\$(find -L $dir/dismod_at -name site-packages) && \
 if [ -e $dir/dismod_at ] ; then rm $dir/dismod_at ; fi && \
 ln -s $dir/dismod_at.debug $dir/dismod_at && \
 bin/check_all.sh
@@ -519,8 +524,6 @@ pip3 install --force-reinstall dist/at_cascade-$at_cascade_version.tar.gz \
 # 4. Test release
 WORKDIR /home/at_cascade.git
 RUN \
-export PATH="\$PATH:$dir/dismod_at/bin" && \
-export PYTHONPATH=\$(find -L $dir/dismod_at -name site-packages) && \
 if [ -e $dir/dismod_at ] ; then rm $dir/dismod_at ; fi && \
 ln -s $dir/dismod_at.release $dir/dismod_at && \
 bin/check_all.sh


### PR DESCRIPTION
Using the ENV command, we can ensure the expected PATH and PYTHONPATH are exported to the final container. Since dismod_at and at_cascade are installed to non-standard directories, we need to add to PATH to be able to import the relevant libraries. Otherwise, users are forced to either add `sys.path.append` to every single Python script or manage their own installations of dismod_at, defeating the purpose of containerization. 