### PR TITLE
fix mismatched variable name in dock_dismod_at.sh

### DIFF
--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -182,8 +182,8 @@ fi
 # ---------------------------------------------------------------------------
 if ! $driver ps > /dev/null
 then
-   echo "Cannot run $dirver ps"
-   if [ "$dirver" == 'docker' ]
+   echo "Cannot run $driver ps"
+   if [ "$driver" == 'docker' ]
    then
 cat << EOF
 If docker deamon is not running perhaps one of the following will start it:


### PR DESCRIPTION
## Type of changes
Bug fix

## Proposed changes
Variable name `driver` was mistyped `dirver` in `dock_dismod_at.sh` on lines 185-186.

## Tests
I don't see an existing test for `dock_dismod_at.sh` but I can try to create one. Will mark ready for review when that's done.