### PR TITLE
Update/linux lts

### DIFF
--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -305,7 +305,7 @@ EOF
 # -----------------------------------------------------------------------------
 elif [ "$1" == 'dismod_at' ]
 then
-site_packages="$prefix/lib/python3.11/site-packages"
+site_packages="$prefix/lib/python3.12/site-packages"
 cat << EOF > Dockerfile
 FROM dismod_at.mixed.$build_type
 WORKDIR /home/dismod_at.git

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -241,11 +241,11 @@ if [ "$1" == 'base' ]
 then
 cat << EOF > Dockerfile
 # -----------------------------------------------------------------------------
-# Ubuntu 23.04 with dismod_at requirements that are installed using apt-get.
+# Ubuntu 24.04 with dismod_at requirements that are installed using apt-get.
 # The vim editor is included for use when debugging containers and
 # is not required by dismod_at.
 # -----------------------------------------------------------------------------
-FROM ubuntu:23.04
+FROM ubuntu:24.04
 RUN  apt-get update
 WORKDIR /home
 #


### PR DESCRIPTION
## Update docker image to ubuntu:24.04

The version of ubuntu currently used to build the base docker image in `bin/dock_dismod_at.sh` is deprecated, causing downstream tools used by our org to fail when building using this file. This update moves the version to a *long term support* version of ubuntu that will receive standard support until 2029 and extended support for an additional 5 years. 