### PR TITLE
Chore: Add a CITATION.cff file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,9 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+- family-names: "Bell"
+  given-names: "Bradley"
+title: "DisMod-AT"
+version: 2025.0.1
+date-released: 2025-03-21
+url: "https://github.com/bradbell/dismod_at"


### PR DESCRIPTION
# What is this for

A CITATION.cff file goes in the root of the repository and activates a GitHub feature which generates citations for users of the software. GitHub's [citation file page](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files) has more info.

# Why is this needed

Users will want to be able to cite the software in their work, especially with dismod_at now having a stable release, and this will help them to do so easily.