### PR TITLE
Split create table insertion: Set a max number of rows and split if more are present

### DIFF
--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='c3cfd4417165231614ac35d861169c664220ca0b'
+   dismod_at_hash='9b246390ad61fe202839f8e34a5bf76fdd639745'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='1bbf4013f045366c22e6d85563e52816842ad30a'
+   dismod_at_hash='3dbb4d26eb57488df7e6a316759d32f70a154862'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='af8c80d94a2afa2c80471803f451825e1199d11a'
+   dismod_at_hash='a2ec56d7b260f31f20b2e2b8c0a94ff5b924d246'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='657f9f06a3d607fa52bd3345fab36ef37c223458'
+   dismod_at_hash='af8c80d94a2afa2c80471803f451825e1199d11a'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -104,7 +104,7 @@ set -e -u
 # ``docker`` or ``podman`` :
 # {xrst_spell_off}
 # {xrst_code sh}
-   driver='podman'
+   driver='docker'
 # {xrst_code}
 # {xrst_spell_on}
 # Above and below we refer to the value of this shell variable as *driver* .
@@ -155,8 +155,8 @@ set -e -u
 # This script can build the following version of ``dismod_at.dismod_at``
 # {xrst_spell_off}
 # {xrst_code sh}
-   dismod_at_version='2025.7.6'
-   dismod_at_hash='97cb2fd43d8b99c9cd1e0cfb8417abcead49cf55'
+   dismod_at_version='2025.7.11'
+   dismod_at_hash='c3cfd4417165231614ac35d861169c664220ca0b'
 # {xrst_code}
 # {xrst_spell_on}
 #
@@ -296,7 +296,7 @@ FROM dismod_at.base
 WORKDIR /home
 #
 # Get source corresponding to dismod_at-$dismod_at_version
-RUN git clone https://github.com/bradbell/dismod_at.git dismod_at.git
+RUN git clone https://github.com/garland-culbreth/dismod_at dismod_at.git
 #
 # WORKDIR
 WORKDIR /home/dismod_at.git

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='b1f06c7cf973cbf42c410aa2e03c2b29c907abdc'
+   dismod_at_hash='1bbf4013f045366c22e6d85563e52816842ad30a'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='9b246390ad61fe202839f8e34a5bf76fdd639745'
+   dismod_at_hash='b1f06c7cf973cbf42c410aa2e03c2b29c907abdc'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/bin/dock_dismod_at.sh
+++ b/bin/dock_dismod_at.sh
@@ -156,7 +156,7 @@ set -e -u
 # {xrst_spell_off}
 # {xrst_code sh}
    dismod_at_version='2025.7.11'
-   dismod_at_hash='3dbb4d26eb57488df7e6a316759d32f70a154862'
+   dismod_at_hash='657f9f06a3d607fa52bd3345fab36ef37c223458'
 # {xrst_code}
 # {xrst_spell_on}
 #

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -163,7 +163,7 @@ void create_table(
       return;
    //
    // data for the multiple insert
-   size_t cut_size = 5000000
+   size_t cut_size = 5000000;
    for(size_t n = cut_size; n <= n_row; n += cut_size)
    {  if (n > n_row)
          n = n_row;

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -163,12 +163,14 @@ void create_table(
       return;
    //
    // data for the multiple insert
+   std::cout << "CREATE_TABLE.CPP : table_name = " << table_name << std::endl;
+   std::cout << "CREATE_TABLE.CPP : n_row = " << n_row << std::endl;
    size_t cut_size = 5000000;
    for(size_t n = cut_size; n < n_row+cut_size; n += cut_size)
    {  size_t i_start = n - cut_size;
       if (n > n_row)
          n = n_row;
-         std::cout << "CUT LOOP TEST: n = " << n << std::endl;
+         std::cout << "CREATE_TABLE.CPP : cut n = " << n << std::endl;
       for(size_t i = i_start; i < n; i++)
       {  cmd_n = cmd + "( "  + to_string(i);
          for(size_t j = 0; j < n_col; j++)

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -164,7 +164,7 @@ void create_table(
    //
    // data for the multiple insert
    size_t cut_size = 5000000;
-   for(size_t n = cut_size; n <= n_row; n += cut_size)
+   for(size_t n = 0; n <= n_row; n += cut_size)
    {  if (n > n_row)
          n = n_row;
       for(size_t i = n - cut_size; i < n; i++)

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -159,8 +159,6 @@ void create_table(
       cmd += ", " + col_name[j];
    cmd += " ) values\n";
    //
-   std::cout << "CREATE_TABLE.CPP : cmd = " << cmd << std::endl;
-   //
    if( n_row == 0 )
       return;
    //
@@ -173,6 +171,7 @@ void create_table(
       if (n > n_row)
          n = n_row;
          std::cout << "CREATE_TABLE.CPP : cut n = " << n << std::endl;
+         std::cout << "CREATE_TABLE.CPP : i_start = " << i_start << std::endl;
       for(size_t i = i_start; i < n; i++)
       {  cmd_n = cmd + "( "  + to_string(i);
          for(size_t j = 0; j < n_col; j++)

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -133,8 +133,7 @@ void create_table(
 {  using CppAD::to_string;
 
    std::string cmd;
-   std::string cmd1;
-   std::string cmd2;
+   std::string cmd_n;
    size_t n_col = col_name.size();
    size_t n_row = row_value.size() / n_col;
    //
@@ -164,61 +163,28 @@ void create_table(
       return;
    //
    // data for the multiple insert
-   if (n_row < 1000000000)
-   {  for(size_t i = 0; i < n_row; i++)
-      {  cmd += "( "  + to_string(i);
+   size_t cut_size = 5000000
+   for(size_t n = cut_size; n <= n_row; n += cut_size)
+   {  if (n > n_row)
+         n = n_row;
+      for(size_t i = n - cut_size; i < n; i++)
+      {  cmd_n = cmd + "( "  + to_string(i);
          for(size_t j = 0; j < n_col; j++)
-         {  cmd += ", ";
+         {  cmd_n += ", ";
             if( col_type[j] == "text" )
-               cmd += "'" + row_value[i * n_col + j] + "'";
+               cmd_n += "'" + row_value[i * n_col + j] + "'";
             else if( row_value[i * n_col + j] == "" )
-               cmd += "null";
+               cmd_n += "null";
             else
-               cmd += row_value[i * n_col + j];
+               cmd_n += row_value[i * n_col + j];
          }
-         if( i + 1 < n_row )
-            cmd += " ),\n";
+         if( i + 1 < n )
+            cmd_n += " ),\n";
          else
-            cmd += " )\n";
+            cmd_n += " )\n";
       }
-      dismod_at::exec_sql_cmd(db, cmd);
-   } else
-   {  for(size_t i = 0; i < 1000000000; i++)
-      {  cmd1 = cmd + "( "  + to_string(i);
-         for(size_t j = 0; j < n_col; j++)
-         {  cmd1 += ", ";
-            if( col_type[j] == "text" )
-               cmd1 += "'" + row_value[i * n_col + j] + "'";
-            else if( row_value[i * n_col + j] == "" )
-               cmd1 += "null";
-            else
-               cmd1 += row_value[i * n_col + j];
-         }
-         if( i + 1 < 1000000000 )
-            cmd1 += " ),\n";
-         else
-            cmd1 += " )\n";
-      }
-      for(size_t i = 1000000000; i < n_row; i++)
-      {  cmd2 = cmd + "( "  + to_string(i);
-         for(size_t j = 0; j < n_col; j++)
-         {  cmd2 += ", ";
-            if( col_type[j] == "text" )
-               cmd2 += "'" + row_value[i * n_col + j] + "'";
-            else if( row_value[i * n_col + j] == "" )
-               cmd2 += "null";
-            else
-               cmd2 += row_value[i * n_col + j];
-         }
-         if( i + 1 < n_row )
-            cmd2 += " ),\n";
-         else
-            cmd2 += " )\n";
-      }
-      dismod_at::exec_sql_cmd(db, cmd1);
-      dismod_at::exec_sql_cmd(db, cmd2);
+      dismod_at::exec_sql_cmd(db, cmd_n);
    }
-
 }
 
 } // END_DISMOD_AT_NAMESPACE

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -163,15 +163,11 @@ void create_table(
       return;
    //
    // data for the multiple insert
-   std::cout << "CREATE_TABLE.CPP : table_name = " << table_name << std::endl;
-   std::cout << "CREATE_TABLE.CPP : n_row = " << n_row << std::endl;
    size_t cut_size = 5000000;
    for(size_t n = cut_size; n < n_row+cut_size; n += cut_size)
    {  size_t i_start = n - cut_size;
       if (n > n_row)
          n = n_row;
-         std::cout << "CREATE_TABLE.CPP : cut n = " << n << std::endl;
-         std::cout << "CREATE_TABLE.CPP : i_start = " << i_start << std::endl;
       cmd_n = cmd;
       for(size_t i = i_start; i < n; i++)
       {  cmd_n = cmd_n + "( "  + to_string(i);
@@ -189,7 +185,6 @@ void create_table(
          else
             cmd_n += " )\n";
       }
-      std::cout << "CREATE_TABLE.CPP : cmd_n = " << cmd_n << std::endl;
       dismod_at::exec_sql_cmd(db, cmd_n);
    }
 }

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -164,10 +164,11 @@ void create_table(
    //
    // data for the multiple insert
    size_t cut_size = 5000000;
-   for(size_t n = 0; n <= n_row; n += cut_size)
-   {  if (n > n_row)
+   for(size_t n = cut_size; n < n_row+cut_size; n += cut_size)
+   {  size_t i_start = n - cut_size;
+      if (n > n_row)
          n = n_row;
-      for(size_t i = n - cut_size; i < n; i++)
+      for(size_t i = i_start; i < n; i++)
       {  cmd_n = cmd + "( "  + to_string(i);
          for(size_t j = 0; j < n_col; j++)
          {  cmd_n += ", ";

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -172,8 +172,9 @@ void create_table(
          n = n_row;
          std::cout << "CREATE_TABLE.CPP : cut n = " << n << std::endl;
          std::cout << "CREATE_TABLE.CPP : i_start = " << i_start << std::endl;
+      cmd_n = cmd;
       for(size_t i = i_start; i < n; i++)
-      {  cmd_n = cmd + "( "  + to_string(i);
+      {  cmd_n = cmd_n + "( "  + to_string(i);
          for(size_t j = 0; j < n_col; j++)
          {  cmd_n += ", ";
             if( col_type[j] == "text" )

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -168,6 +168,7 @@ void create_table(
    {  size_t i_start = n - cut_size;
       if (n > n_row)
          n = n_row;
+         std::cout << "CUT LOOP TEST: n = " << n << std::endl;
       for(size_t i = i_start; i < n; i++)
       {  cmd_n = cmd + "( "  + to_string(i);
          for(size_t j = 0; j < n_col; j++)

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -133,6 +133,8 @@ void create_table(
 {  using CppAD::to_string;
 
    std::string cmd;
+   std::string cmd1;
+   std::string cmd2;
    size_t n_col = col_name.size();
    size_t n_row = row_value.size() / n_col;
    //
@@ -162,23 +164,61 @@ void create_table(
       return;
    //
    // data for the multiple insert
-   for(size_t i = 0; i < n_row; i++)
-   {  cmd += "( "  + to_string(i);
-      for(size_t j = 0; j < n_col; j++)
-      {  cmd += ", ";
-         if( col_type[j] == "text" )
-            cmd += "'" + row_value[i * n_col + j] + "'";
-         else if( row_value[i * n_col + j] == "" )
-            cmd += "null";
+   if (n_row < 1000000000)
+   {  for(size_t i = 0; i < n_row; i++)
+      {  cmd += "( "  + to_string(i);
+         for(size_t j = 0; j < n_col; j++)
+         {  cmd += ", ";
+            if( col_type[j] == "text" )
+               cmd += "'" + row_value[i * n_col + j] + "'";
+            else if( row_value[i * n_col + j] == "" )
+               cmd += "null";
+            else
+               cmd += row_value[i * n_col + j];
+         }
+         if( i + 1 < n_row )
+            cmd += " ),\n";
          else
-            cmd += row_value[i * n_col + j];
+            cmd += " )\n";
       }
-      if( i + 1 < n_row )
-         cmd += " ),\n";
-      else
-         cmd += " )\n";
+      dismod_at::exec_sql_cmd(db, cmd);
+   } else
+   {  for(size_t i = 0; i < 1000000000; i++)
+      {  cmd1 = cmd + "( "  + to_string(i);
+         for(size_t j = 0; j < n_col; j++)
+         {  cmd1 += ", ";
+            if( col_type[j] == "text" )
+               cmd1 += "'" + row_value[i * n_col + j] + "'";
+            else if( row_value[i * n_col + j] == "" )
+               cmd1 += "null";
+            else
+               cmd1 += row_value[i * n_col + j];
+         }
+         if( i + 1 < 1000000000 )
+            cmd1 += " ),\n";
+         else
+            cmd1 += " )\n";
+      }
+      for(size_t i = 1000000000; i < n_row; i++)
+      {  cmd2 = cmd + "( "  + to_string(i);
+         for(size_t j = 0; j < n_col; j++)
+         {  cmd2 += ", ";
+            if( col_type[j] == "text" )
+               cmd2 += "'" + row_value[i * n_col + j] + "'";
+            else if( row_value[i * n_col + j] == "" )
+               cmd2 += "null";
+            else
+               cmd2 += row_value[i * n_col + j];
+         }
+         if( i + 1 < n_row )
+            cmd2 += " ),\n";
+         else
+            cmd2 += " )\n";
+      }
+      dismod_at::exec_sql_cmd(db, cmd1);
+      dismod_at::exec_sql_cmd(db, cmd2);
    }
-   dismod_at::exec_sql_cmd(db, cmd);
+
 }
 
 } // END_DISMOD_AT_NAMESPACE

--- a/devel/table/create_table.cpp
+++ b/devel/table/create_table.cpp
@@ -159,6 +159,8 @@ void create_table(
       cmd += ", " + col_name[j];
    cmd += " ) values\n";
    //
+   std::cout << "CREATE_TABLE.CPP : cmd = " << cmd << std::endl;
+   //
    if( n_row == 0 )
       return;
    //
@@ -187,6 +189,7 @@ void create_table(
          else
             cmd_n += " )\n";
       }
+      std::cout << "CREATE_TABLE.CPP : cmd_n = " << cmd_n << std::endl;
       dismod_at::exec_sql_cmd(db, cmd_n);
    }
 }

--- a/test/user/zero_random_2.py
+++ b/test/user/zero_random_2.py
@@ -228,6 +228,7 @@ for command in [ 'init', 'fit' ] :
       cmd.append(variables)
    print( ' '.join(cmd) )
    flag = subprocess.call( cmd )
+   print(flag)
    if flag != 0 :
       sys.exit('The dismod_at ' + command + ' command failed')
 # -----------------------------------------------------------------------


### PR DESCRIPTION
Note: I'm opening this as a draft so progress can be tracked more easily, but it's not yet ready (see the TODO items)

# Proposed changes

In `devel/table/create_table.cpp`, if the number of rows is greater than a maximum cutoff size, split the insertion statement into multiple.

# Why is this needed

In situations where there are a large number of grid points in age/time, a large number of covariates, and a large number of samples, it can happen that the number of rows being inserted into the variable table in `dismod.db` is too large for sqlite's maximum string length ([sqlite limit 1](https://www.sqlite.org/limits.html)). Splitting the statement up into multiple avoids this problem.

# Tests

I have `bin/check_all.sh` passing with these changes as-is, but it only utilized the `if {}` case, which doesn't invoke the split. TODO: Make a new test for the `else {}` case.

# TODO

- [x] Instead of using just one threshold, increment by a large number, e.g., 5 million, and iterate over that inserting each time.
- [ ] Make a new test for the `else {}` case, where the split is invoked.
- [x] Determine the proper maximum string length to use as cutoff. I picked 1 billion initially but this may be too large.